### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.order("created_at DESC")
+    @items = Item.order("created_at DESC") #並び替え
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
 
   def index
     @items = Item.order("created_at DESC") #並び替え
-    @items = Item.all
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,30 +128,32 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <% @items.each do |item| %>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag "item-sample.png", class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+                <%# [未実装]商品が売れていればsold outを表示しましょう %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+                <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= "商品名" %>
+            </h3>
+            <div class='item-price'>
+              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
+          <% end %>
+        <% end %>  
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,21 +131,21 @@
         <% @items.each do |item| %>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
+            <%= image_tag item.image, class: "item-img" %>
 
                 <%# [未実装]商品が売れていればsold outを表示しましょう %>
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div>
+                <%# <div class='sold-out'> %>
+                  <%# <span>Sold Out!!</span> %>
+                <%# </div> %>
                 <%# //商品が売れていればsold outを表示しましょう %>
 
           </div>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%= "商品名" %>
+              <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+              <span><%= item.payment %>円<br><%= '配送料負担' %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,4 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items
-  
 end


### PR DESCRIPTION
レビューお願いします。
#what
出品されている商品の一覧が表示できている
#why
出品された商品をユーザーが見られるようにするため

#キャプチャ
出品した商品の一覧表示ができていること
https://gyazo.com/571f028bfa2184fa9c74748c196b9e1a
上から、出品された日時が新しい順に表示されること
https://gyazo.com/25f498b1c485c6f4fcd5d800abbd7a5f
「画像/価格/商品名」の3つの情報について表示できていること
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
https://gyazo.com/bc7b683e15976e0deb180414cb9154c7
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/b4853bee74616311d00e5cc1fe7c8603
